### PR TITLE
Verify ai agent local execution after merge

### DIFF
--- a/src/ollama_client.py
+++ b/src/ollama_client.py
@@ -3,6 +3,8 @@ from typing import List, Dict
 
 class OllamaClient:
     def __init__(self):
+        # Instantiate a reusable Ollama client
+        self.client = ollama.Client()
 
     def get_available_models(self) -> List[str]:
         """Get list of available Ollama models with error handling"""
@@ -10,8 +12,8 @@ class OllamaClient:
             models = self.client.list()
             return [model['name'] for model in models['models']]
         except Exception as e:
-            st.error(f"Error fetching models: {e}")
-            return ["llama2", "mistral"]  # Fallback
+            # Avoid UI dependencies here; return reasonable defaults
+            return ["llama2", "mistral"]
 
     def generate_response(self, prompt: str, history: List[Dict], model: str) -> str:
         """Generate response from Ollama model with error handling"""


### PR DESCRIPTION
Implement core chat generation, document processing, and RAG features, and fix initialization issues in the Streamlit app and Ollama client to enable local execution via Docker.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ac0cd2d-f064-4a9a-b830-6f240855d7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ac0cd2d-f064-4a9a-b830-6f240855d7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements RAG-aware chat flow with document ingestion (pdf/txt/md), adds agent/session defaults, and fixes Ollama client initialization and error handling.
> 
> - **App (`src/app.py`)**:
>   - **Chat/RAG**: Build system prompt per agent, optionally retrieve RAG context from `vector_db`, augment prompt, generate reply, append assistant message, and persist conversation.
>   - **Session defaults**: Add `current_agent` and `use_rag` to session state; move `init_session_state` after service initialization.
>   - **Document Processing**: Rename button to `Process Document`; support `pdf/txt/md`, split plain text into chunks via `_split_text`, store chunks in `vector_db`, and show success/warnings.
> - **Ollama Client (`src/ollama_client.py`)**:
>   - Instantiate reusable `ollama.Client()`; on errors return default models without UI calls; keep chat generation with recent history.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53cca6677e8983ba2f5fb29058257907e70fd3e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->