### PR TITLE
Install docker for ai agent playground

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,57 +1,147 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo "🚀 Setting up AI Agent Playground..."
 
-# Check if Docker is installed and running
-if ! command -v docker &> /dev/null; then
-    echo "❌ Docker not found. Please install Docker first."
-    echo "For Zorin OS (Ubuntu-based):"
-    echo "sudo apt update && sudo apt install docker.io docker-compose"
-    echo "sudo usermod -aG docker $USER && newgrp docker"
+have_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+require_sudo() {
+    if [[ $(id -u) -ne 0 ]] && ! have_cmd sudo; then
+        echo "❌ This script needs administrative privileges but 'sudo' is not available."
+        exit 1
+    fi
+}
+
+apt_install() {
+    sudo apt-get update -y
+    sudo apt-get install -y "$@"
+}
+
+install_docker_apt() {
+    echo "🔧 Installing Docker Engine (Ubuntu/Zorin)..."
+    # Remove potentially conflicting packages
+    sudo apt-get remove -y docker docker-engine docker.io containerd runc || true
+    apt_install ca-certificates curl gnupg lsb-release
+    sudo install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+    # Derive codename compatible with Ubuntu repo (Zorin is Ubuntu-based)
+    . /etc/os-release
+    UBUNTU_CODENAME_COMPUTED="${UBUNTU_CODENAME:-${VERSION_CODENAME:-focal}}"
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${UBUNTU_CODENAME_COMPUTED} stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+    apt_install apt-transport-https
+    sudo apt-get update -y
+    # Install Docker + Compose plugin
+    apt_install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+    echo "✅ Docker installed. Enabling and starting service..."
+    sudo systemctl enable --now docker || true
+}
+
+install_postgres_client_apt() {
+    echo "🔧 Installing PostgreSQL client (psql)..."
+    apt_install postgresql-client || true
+}
+
+ensure_docker() {
+    if ! have_cmd docker; then
+        # Detect apt-based systems (Ubuntu/Zorin/Debian)
+        if [[ -f /etc/os-release ]]; then
+            . /etc/os-release
+            if [[ "${ID_LIKE:-}" == *"debian"* ]] || [[ "${ID:-}" == "ubuntu" ]] || [[ "${ID:-}" == "zorin" ]]; then
+                require_sudo
+                install_docker_apt
+            else
+                echo "❌ Unsupported distro for automated Docker install (ID=${ID:-unknown}). Install Docker manually."
+                exit 1
+            fi
+        else
+            echo "❌ Cannot detect OS. Install Docker manually."
+            exit 1
+        fi
+    fi
+
+    # Ensure daemon is running
+    if ! docker info >/dev/null 2>&1; then
+        echo "🔁 Starting Docker daemon..."
+        require_sudo
+        sudo systemctl start docker || true
+        sleep 2
+    fi
+}
+
+# Install Docker if missing and ensure daemon
+ensure_docker
+
+# Optionally install psql for convenience on apt systems
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    if [[ "${ID_LIKE:-}" == *"debian"* ]] || [[ "${ID:-}" == "ubuntu" ]] || [[ "${ID:-}" == "zorin" ]]; then
+        install_postgres_client_apt || true
+    fi
+fi
+
+# Handle docker group membership; fall back to sudo when needed
+DOCKER_PREFIX=""
+if ! groups "$USER" | grep -q '\bdocker\b'; then
+    echo "⚠️  Adding user '$USER' to 'docker' group (to avoid using sudo)..."
+    require_sudo
+    sudo usermod -aG docker "$USER" || true
+    echo "ℹ️  You'll need to log out/in for group changes to apply. Continuing this run with sudo..."
+    DOCKER_PREFIX="sudo "
+fi
+
+# Verify Docker works
+${DOCKER_PREFIX}docker --version | sed 's/^/✅ /'
+if ${DOCKER_PREFIX}docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD="${DOCKER_PREFIX}docker compose"
+elif have_cmd docker-compose; then
+    COMPOSE_CMD="${DOCKER_PREFIX}docker-compose"
+else
+    echo "❌ Docker Compose not available even after install."
+    echo "   Ensure 'docker-compose-plugin' is installed or install 'docker-compose' binary."
     exit 1
 fi
 
-# Check if Docker daemon is running
-if ! docker info > /dev/null 2>&1; then
-    echo "❌ Docker daemon not running. Starting Docker..."
-    sudo systemctl start docker
-    sleep 3
-fi
-
-# Check if user is in docker group
-if ! groups $USER | grep -q '\bdocker\b'; then
-    echo "⚠️  Adding user to docker group..."
-    sudo usermod -aG docker $USER
-    echo "✅ Please log out and log back in, or run: newgrp docker"
-    exit 1
-fi
-
-# Check if Ollama is installed
-if ! command -v ollama &> /dev/null; then
+# Check if Ollama is installed (optional local runtime)
+if ! have_cmd ollama; then
     echo "❌ Ollama not found. Installing Ollama..."
-    curl -fsSL https://ollama.ai/install.sh | sh
+    curl -fsSL https://ollama.ai/install.sh | sh || true
 fi
 
-# Create .env file if it doesn't exist
+# Create .env with sensible defaults if missing (used for local dev)
 if [ ! -f .env ]; then
-
+    echo "📝 Creating default .env file..."
+    cat > .env << 'EOF'
+# Local development defaults (Docker Compose sets its own env for containers)
+OLLAMA_HOST=http://localhost:11434
+EMBED_MODEL=nomic-embed-text
+EMBED_DIM=768
+MCP_URL=http://localhost:8080
+EOF
+fi
 
 # Build and start containers
 echo "🐳 Building and starting Docker containers..."
-docker-compose down  # Clean up any old containers
-docker-compose build --no-cache  # Fresh build
+${COMPOSE_CMD} down || true
+${COMPOSE_CMD} build --no-cache
 
-if docker-compose up -d; then
+if ${COMPOSE_CMD} up -d; then
     echo "✅ Setup complete!"
     echo ""
     echo "🌐 Streamlit app: http://localhost:8501"
-    echo "🗄️  PostgreSQL: localhost:5432"
+    echo "🗄️  PostgreSQL (in Docker): localhost:5432"
     echo ""
     echo "📋 Useful commands:"
-    echo "   View logs: docker-compose logs -f streamlit-app"
-    echo "   Stop services: docker-compose down"
-    echo "   Restart: docker-compose restart"
+    echo "   View logs: ${COMPOSE_CMD} logs -f streamlit-app"
+    echo "   Stop services: ${COMPOSE_CMD} down"
+    echo "   Restart: ${COMPOSE_CMD} restart"
 else
-    echo "❌ Docker compose failed. Check the errors above."
+    echo "❌ Docker Compose failed. Check the errors above."
     exit 1
 fi


### PR DESCRIPTION
Automate Docker Engine and Compose installation for Ubuntu/Zorin in `setup.sh` to streamline project setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-dadbe4f9-835c-441a-90ee-bdc133aad52b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dadbe4f9-835c-441a-90ee-bdc133aad52b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Overhauls `setup.sh` to auto-install/configure Docker and Compose on apt-based distros, add default `.env`, handle docker group/sudo, and standardize compose commands with optional Ollama and psql installs.
> 
> - **Setup script (`setup.sh`)**:
>   - Automates Docker Engine + Compose installation for apt-based distros; ensures daemon running.
>   - Detects Compose plugin vs legacy `docker-compose` and centralizes via `COMPOSE_CMD`.
>   - Handles `docker` group membership; falls back to `sudo` when needed.
>   - Creates default `.env` with `OLLAMA_HOST`, `EMBED_MODEL`, `EMBED_DIM`, `MCP_URL`.
>   - Optional installs: Ollama; PostgreSQL client on apt systems.
>   - Adds safety flags (`set -euo pipefail`) and helper functions; refactors build/up/down commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d0de47b2eae381b1168e82e2c1c852c8fe9590b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->